### PR TITLE
fix: remove ide files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Default ignored files
-/.idea/*
-/.vscode/*


### PR DESCRIPTION
In this PR, I am removing files from `.gitignore` as they should be in the global file `.gitignore_global`.